### PR TITLE
Add ResumeAI under Resume preparation tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Tools:
 * 🔨 Enhancv's [Resume Builder](https://enhancv.com/get-started/relocate-me-resume/?utm_source=relocateme&utm_medium=affiliate&utm_campaign=enhancv-relocateme-github&utm_content=list) 
 * 🔨 A free and fast [AI Resume Checker](https://enhancv.com/resources/resume-checker/?utm_source=relocateme&utm_medium=affiliate&utm_campaign=enhancv-relocateme-github&utm_content=resume-section) for instant resume feedback
 * 🔨 [FlowCV](https://flowcv.io/resume-templates) for resume templates
+* 🔨 [ResumeAI](https://withresumeai.com/) free ATS checker + AI resume builder (3/day with no account); State of ATS 2026 open dataset
   
 
 


### PR DESCRIPTION
Adds [ResumeAI](https://withresumeai.com/) — free ATS checker (3/day without an account) and AI resume builder.

Verified facts only:
- Domain: https://withresumeai.com/ (not resume.ai)
- State of ATS 2026: 738 employers / 704 portal-verified ([dataset](https://github.com/Kayvan-Zahiri/state-of-ats-2026))
- Live candidate leaderboard is paid placement/visibility — not pay-for-score / not pay-to-get-hired

Happy to adjust wording or section placement.